### PR TITLE
Finish function that deletes mini-poster from the savedPosters array

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -176,31 +176,43 @@ function addSavedPoster() {
       savedPosters[i].imageURL === selectImg.src &&
       savedPosters[i].title === selectTitle.innerHTML &&
       savedPosters[i].quote === selectQuote.innerHTML
-      )
-    { return;
+    ) {
+      return;
     }
   }
   savedPosters.push(currentPoster);
 };
 
 function showSavedPosterPage() {
-
   savedPostersGrid.innerHTML = ""
-
   savedPosterPage.classList.remove("hidden");
   mainPoster.classList.add("hidden");
-
   for (var i = 0; i < savedPosters.length; i++) {
     savedPostersGrid.innerHTML +=
-      `<div class="mini-poster">
+      `<div class="mini-poster" id="${savedPosters[i].id}">
    <img src="${savedPosters[i].imageURL}">
    <h2>${savedPosters[i].title}</h2>
    <h4>${savedPosters[i].quote}</h4>
  </div>`
+  }
+  deletingSavedPosters();
+};
+
+function deletingSavedPosters() {
+  var miniPoster = document.querySelectorAll('.mini-poster')
+    .forEach(item => {
+      item.addEventListener('dblclick', event => {
+        var id = event.target.closest("div").id
+        removeSavedPoster(id);
+        item.remove('id')
+      })
+    });
+};
+
+function removeSavedPoster(id) {
+  for (var i = 0; i < savedPosters.length; i++) {
+    if (parseInt(id) === savedPosters[i].id) {
+      savedPosters.splice(i, 1)
+    }
   };
-  var miniPoster = document.querySelectorAll('.mini-poster').forEach(item => {
-    item.addEventListener('dblclick', event => {
-      item.remove('id');
-    })
-  });
 };


### PR DESCRIPTION
#### What does this PR do?
- The remove saved poster function is fired in the deletingSavedPosters function
- This fixes the bug we encountered when navigating back to the Saved Posters page the posters we deleted would re-populate because they were still in the array and only deleted from the DOM
- We used the beautify extension to finish the code

#### Where should the reviewer start?
- deletingSavedPosters function

#### How should this be manually tested?
- Functionality

#### Any background context you want to provide?
- We encountered when navigating back to the Saved Posters page the posters we deleted would re-populate because they were still in the array and only deleted from the DOM
- The parseInt was used to convert the sting to a number
